### PR TITLE
Fix/ade delay

### DIFF
--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -44,8 +44,8 @@ jobs:
             - template: ../tasks/azpwsh_inline_execute_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
-                inlineScript: 'Start-Sleep -Seconds ${{ parameters.secondsToPause }}'
-                displayName: 'Pause for ${{ parameters.secondsToPause }} Previous Infrastructure Job Deployment'
+                inlineScript: 'Start-Sleep -Seconds ${{ variables.secondsToPause }}'
+                displayName: 'Pause for ${{ variables.secondsToPause }} Previous Infrastructure Job Deployment'
             - template: ../tasks/ado_webapp_deploy_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}

--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -35,14 +35,17 @@ jobs:
     value: '${{ parameters.serviceName }}_app_deploy_${{ parameters.environmentName }}_${{ parameters.regionAbrv }}'
   - name: webAppName
     value: '${{ variables.webAppAbrv }}-${{ parameters.serviceName }}-${{ parameters.environmentName }}-${{ parameters.regionAbrv }}'
+  - name: secondsToPause
+    value: 60
   strategy:
     runOnce:
         deploy:
             steps:
-            - template: ../tasks/azcli_inline_script_task.yml
+            - template: ../tasks/azpwsh_inline_execute_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
-                inlineScript: 'az webapp show --name ${{ variables.webAppName }}'
+                inlineScript: 'Start-Sleep -Seconds ${{ parameters.secondsToPause }}'
+                displayName: 'Pause for ${{ parameters.secondsToPause }} Previous Infrastructure Job Deployment'
             - template: ../tasks/ado_webapp_deploy_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}

--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -20,6 +20,9 @@ parameters:
 - name: webAppType
   type: string
   default: 'webApp'
+- name: delayInMinutes
+  type: string
+  default: '1'
 
 jobs:
 - deployment: '${{ parameters.serviceName }}_app_${{ parameters.environmentName }}_${{ parameters.regionAbrv }}'
@@ -34,6 +37,9 @@ jobs:
     runOnce:
         deploy:
             steps:
+            - template: ../taska/ado_delay_task.yml
+              parameters:
+                delayInMinutes: ${{ parameters.delayInMinutes }}
             - template: ../tasks/ado_webapp_deploy_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}

--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -37,7 +37,7 @@ jobs:
     runOnce:
         deploy:
             steps:
-            - template: ../taska/ado_delay_task.yml
+            - template: ../tasks/ado_delay_task.yml
               parameters:
                 delayInMinutes: ${{ parameters.delayInMinutes }}
             - template: ../tasks/ado_webapp_deploy_task.yml

--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -33,17 +33,20 @@ jobs:
   - template: ../variables/azure_global_variables.yml
   - name: deploymentName
     value: '${{ parameters.serviceName }}_app_deploy_${{ parameters.environmentName }}_${{ parameters.regionAbrv }}'
+  - name: webAppName
+    value: '${{ variables.webAppAbrv }}-${{ parameters.serviceName }}-${{ parameters.environmentName }}-${{ parameters.regionAbrv }}'
   strategy:
     runOnce:
         deploy:
             steps:
-            - template: ../tasks/ado_delay_task.yml
+            - template: ../tasks/azcli_inline_script_task.yml
               parameters:
-                delayInMinutes: ${{ parameters.delayInMinutes }}
+                azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
+                inlineScript: 'az webapp show ${{ variables.webAppName }}'
             - template: ../tasks/ado_webapp_deploy_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
-                WebAppName: '${{ variables.webAppAbrv }}-${{ parameters.serviceName }}-${{ parameters.environmentName }}-${{ parameters.regionAbrv }}'
+                WebAppName:  ${{ variables.webAppName }}
                 packageForLinux: ${{ parameters.packageForLinux }}
                 InlineScript: ${{ parameters.inLineScript }}
                 webAppType: ${{ parameters.webAppType }}

--- a/jobs/webapp_deploy_env_job.yml
+++ b/jobs/webapp_deploy_env_job.yml
@@ -42,7 +42,7 @@ jobs:
             - template: ../tasks/azcli_inline_script_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
-                inlineScript: 'az webapp show ${{ variables.webAppName }}'
+                inlineScript: 'az webapp show --name ${{ variables.webAppName }}'
             - template: ../tasks/ado_webapp_deploy_task.yml
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}

--- a/tasks/ado_delay_task.yml
+++ b/tasks/ado_delay_task.yml
@@ -7,4 +7,4 @@ parameters:
 steps:
 - task: Delay@1
   inputs:
-    delayForMinutes: ${{ parameters.deplayInMinutes }}
+    delayForMinutes: ${{ parameters.delayInMinutes }}

--- a/tasks/ado_delay_task.yml
+++ b/tasks/ado_delay_task.yml
@@ -3,7 +3,7 @@ parameters:
   type: string
   default: '0'
   
-
+pool: server
 steps:
 - task: Delay@1
   inputs:

--- a/tasks/ado_delay_task.yml
+++ b/tasks/ado_delay_task.yml
@@ -1,0 +1,10 @@
+parameters:
+- name: delayInMinutes
+  type: string
+  default: '0'
+  
+
+steps:
+- task: Delay@1
+  inputs:
+    delayForMinutes: ${{ parameters.deplayInMinutes }}


### PR DESCRIPTION
This pull request primarily updates the `jobs/webapp_deploy_env_job.yml` and `tasks/ado_delay_task.yml` files to introduce a delay mechanism in the deployment process. The changes include the addition of a new parameter `delayInMinutes` and a new task to pause the deployment process for a specified duration. 

Here are the key changes:

* `jobs/webapp_deploy_env_job.yml`: 
  * A new parameter `delayInMinutes` is introduced to allow for a delay in the deployment process.
  * The `webAppName` variable is now defined in the `jobs:` section, which simplifies the `WebAppName` parameter in the `ado_webapp_deploy_task.yml` template.
  * A new task is added to pause the deployment process for a specified duration. The duration is set by the `secondsToPause` variable, which is set to 60 seconds.

* `tasks/ado_delay_task.yml`: 
  * This new file introduces a task that delays the process for a specified number of minutes. The delay duration is set by the `delayInMinutes` parameter.

These changes aim to provide more control over the deployment process by allowing for pauses at specified intervals.