### PR TITLE
fix: Remove duplicate displayName

### DIFF
--- a/tasks/pwsh_retain_pipeline_task.yml
+++ b/tasks/pwsh_retain_pipeline_task.yml
@@ -8,7 +8,6 @@ steps:
   displayName: 'Retain Pipeline Powershell Task'
   condition: and(succeeded(), not(canceled()))
   name: RetainOnSuccess
-  displayName: Retain on Success
   inputs:
     failOnStderr: true
     targetType: 'inline'


### PR DESCRIPTION
Thanks so much for the templates! Retaining pipeline runs dynamically like this sounds like a good idea. I just ran into the problem that the displayName attribute was defined multiple times, causing the pipeline to be invalid.