### PR TITLE
Feature/synapse

### DIFF
--- a/jobs/synapse_build_job.yml
+++ b/jobs/synapse_build_job.yml
@@ -13,7 +13,7 @@ parameters:
   default: ''
 - name: resourceGroupName
   type: string
-  default: '
+  default: ''
 jobs:
 - job: 'synapse_${{ parameters.serviceName }}_build'
   steps:

--- a/jobs/synapse_build_job.yml
+++ b/jobs/synapse_build_job.yml
@@ -8,10 +8,18 @@ parameters:
 - name: targetWorkspaceName
   type: string
   default: ''
+- name: azureSubscription
+  type: string
+  default: ''
+- name: resourceGroupName
+  type: string
+  default: '
 jobs:
 - job: 'synapse_${{ parameters.serviceName }}_build'
   steps:
     - template: ../tasks/synapse_build_task.yml
       parameters:
         targetWorkspaceName: ${{ parameters.targetWorkspaceName }}
-        synapseDirectory : ${{ parameters.synapseDirectory  }}
+        synapseDirectory: ${{ parameters.synapseDirectory  }}
+        azureSubscription: ${{ parameters.azureSubscription }} 
+        resourceGroupName: ${{ parameters.resourceGroupName }}

--- a/jobs/synapse_deploy_env_job.yml
+++ b/jobs/synapse_deploy_env_job.yml
@@ -52,7 +52,7 @@ jobs:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
                 workspaceName: ${{ variables.workspaceName }}
                 resourceGroupName: ${{ variables.resourceGroupName }}
-                triggers: ${{ parameters.triggers }}
+                triggers: '*'
                 toggleOn: false
             - template: ../tasks/synapse_deploy_task.yml
               parameters:

--- a/stages/synapse_build_stage.yml
+++ b/stages/synapse_build_stage.yml
@@ -14,6 +14,12 @@ parameters:
 - name: parametersArtifactName
   type: string
   default: 'parameters'
+- name: azureSubscription
+  type: string
+  default: ''
+- name: resourceGroupName
+  type: string
+  default: '
 stages:
 - stage: '${{ parameters.serviceName }}_build'
   jobs:
@@ -26,3 +32,5 @@ stages:
       parameters:
         targetPath: ${{ parameters.parametersFolderPath }}
         artifactName: ${{ parameters.parametersArtifactName}}
+        azureSubscription: ${{ parameters.azureSubscription }} 
+        resourceGroupName: ${{ parameters.resourceGroupName }}

--- a/stages/synapse_build_stage.yml
+++ b/stages/synapse_build_stage.yml
@@ -19,18 +19,25 @@ parameters:
   default: ''
 - name: resourceGroupName
   type: string
-  default: '
+  default: ''
+- name: baseEnv
+  default: 'dev2'
+- name: baseRegion
+  default: 'eus'
 stages:
 - stage: '${{ parameters.serviceName }}_build'
+  variables:
+  - template: ../variables/azure_${{ parameters.baseEnv }}_variables.yml
+  - template: ../variables/azure_global_variables.yml
   jobs:
     - template: ../jobs/synapse_build_job.yml
       parameters:
         serviceName: ${{ parameters.serviceName }}
         synapseDirectory: ${{ parameters.synapseDirectory }}
-        targetWorkspaceName: ${{ parameters.targetWorkspaceName }}
+        targetWorkspaceName: '${{variables.synapseAbrv }}-${{ parameters.serviceName }}-${{ parameters.baseEnv }}-${{ parameters.baseRegion }}'
+        azureSubscription: ${{ variables.azureSubscription }} 
+        resourceGroupName: ${{ variables.resourceGroupName }}
     - template: ../jobs/artifact_publish_job.yml
       parameters:
         targetPath: ${{ parameters.parametersFolderPath }}
         artifactName: ${{ parameters.parametersArtifactName}}
-        azureSubscription: ${{ parameters.azureSubscription }} 
-        resourceGroupName: ${{ parameters.resourceGroupName }}

--- a/stages/synapse_deploy_stage.yml
+++ b/stages/synapse_deploy_stage.yml
@@ -4,15 +4,13 @@ parameters:
   default:
       environmentName: 'dev'
       regionAbrvs: ['cus']
+      enableTriggers: '*'
 - name: templateParametersFolder
   type: string
   default: 'parameters'
 - name: serviceName
   type: string
   default: ''
-- name: triggers
-  type: string
-  default: '*'
 - name: templateFile
   type: string
   default: 'export/TemplateForWorkspace.json'
@@ -30,7 +28,7 @@ stages:
             environmentName: ${{ environmentObject.environmentName }}
             serviceName: ${{ parameters.serviceName}}
             regionAbrv: ${{ regionAbrv }}
-            triggers: ${{ parameters.triggers }}
+            triggers: ${{ environmentObject.enableTriggers }}
             templateFile: ${{ parameters.templateFile }}
             overrideParameters: ${{ parameters.overrideParameters }}
             templateParametersFolder: ${{ parameters.templateParametersFolder }}

--- a/tasks/synapse_build_task.yml
+++ b/tasks/synapse_build_task.yml
@@ -4,9 +4,17 @@ parameters:
 - name: synapseDirectory 
   type: string
   default: ''
+- name: azureSubscription
+  type: string
+  default: ''
+- name: resourceGroupName
+  type: string
+  default: ''
 steps:
 - task: Synapse workspace deployment@2
   inputs:
     operation: 'validate'
     TargetWorkspaceName: ${{ parameters.targetWorkspaceName }}
     ArtifactsFolder:  ${{ parameters.synapseDirectory  }}
+    azureSubscription: ${{ parameters.azureSubscription }}
+    ResourceGroupName: ${{ parameters.resourceGroupName }}


### PR DESCRIPTION
This pull request includes several changes to the configuration files for building and deploying Synapse resources. The main changes involve adding new parameters for `azureSubscription` and `resourceGroupName`, and updating how triggers are handled in the deployment stage.

### Parameter Additions:

* [`jobs/synapse_build_job.yml`](diffhunk://#diff-1eea5d3792541ab34bacd01bd227b7ac96b4b8bb8762f1237d26fd76c1147d37R11-R25): Added `azureSubscription` and `resourceGroupName` parameters to the job configuration. (`[jobs/synapse_build_job.ymlR11-R25](diffhunk://#diff-1eea5d3792541ab34bacd01bd227b7ac96b4b8bb8762f1237d26fd76c1147d37R11-R25)`)
* [`stages/synapse_build_stage.yml`](diffhunk://#diff-753a28948faf2952aa64f56309aa763ee5f16f125d308fcac7c62d626e0b2742R17-R39): Added `azureSubscription`, `resourceGroupName`, `baseEnv`, and `baseRegion` parameters to the stage configuration. (`[stages/synapse_build_stage.ymlR17-R39](diffhunk://#diff-753a28948faf2952aa64f56309aa763ee5f16f125d308fcac7c62d626e0b2742R17-R39)`)
* [`tasks/synapse_build_task.yml`](diffhunk://#diff-de2f661826dee17503f8afe1bebf79fc938130224dc84a6bafa37f95772d4768R7-R20): Added `azureSubscription` and `resourceGroupName` parameters to the task configuration. (`[tasks/synapse_build_task.ymlR7-R20](diffhunk://#diff-de2f661826dee17503f8afe1bebf79fc938130224dc84a6bafa37f95772d4768R7-R20)`)

### Trigger Handling:

* [`jobs/synapse_deploy_env_job.yml`](diffhunk://#diff-827f2cf999a48df59d885add7d8ac286fa37f8f09bd803fe883e4f6019c3ce4fL55-R55): Changed the `triggers` parameter to always use `'*'`. (`[jobs/synapse_deploy_env_job.ymlL55-R55](diffhunk://#diff-827f2cf999a48df59d885add7d8ac286fa37f8f09bd803fe883e4f6019c3ce4fL55-R55)`)
* [`stages/synapse_deploy_stage.yml`](diffhunk://#diff-94446f39aa220311c4a669c0b610d436493b8fc6d3ecdfb410ed0d7591d0fe63R7-L15): Removed the `triggers` parameter and replaced it with `enableTriggers` in the environment object. (`[[1]](diffhunk://#diff-94446f39aa220311c4a669c0b610d436493b8fc6d3ecdfb410ed0d7591d0fe63R7-L15)`, `[[2]](diffhunk://#diff-94446f39aa220311c4a669c0b610d436493b8fc6d3ecdfb410ed0d7591d0fe63L33-R31)`)