### PR TITLE
Update dotnetcore_build_publish_job.yml

### DIFF
--- a/jobs/dotnetcore_build_publish_job.yml
+++ b/jobs/dotnetcore_build_publish_job.yml
@@ -12,7 +12,6 @@ parameters:
 
 jobs:
 - job: build_publish_${{parameters.projectName}}
-  dependsOn: GHAzDOCheckJob
   variables:
     projectName: ${{replace(parameters.projectName,'_','.')}}
     srcFilePath: 'src'


### PR DESCRIPTION
This pull request includes a small change to the `jobs/dotnetcore_build_publish_job.yml` file. The change removes the dependency on `GHAzDOCheckJob` for the `build_publish_${{parameters.projectName}}` job.

* [`jobs/dotnetcore_build_publish_job.yml`](diffhunk://#diff-8df908f5325da2bc756840bd6176ffec4ed7cd58d4e7b76b3efec691c01a3a18L15): Removed `dependsOn` property for `build_publish_${{parameters.projectName}}` job.