### PR TITLE
Create azure_tst2_variables.yml

### DIFF
--- a/variables/azure_tst2_variables.yml
+++ b/variables/azure_tst2_variables.yml
@@ -1,0 +1,5 @@
+variables:
+  - name: azureServiceConnectionName
+    value: 'AzureTstExtServiceConnection'
+  - name: azureSubscriptionID
+    value: '898e66c4-4550-43c4-93a1-2d3c16932df2'


### PR DESCRIPTION
This pull request includes changes to the `variables/azure_tst2_variables.yml` file to add new Azure service connection variables.

* [`variables/azure_tst2_variables.yml`](diffhunk://#diff-0de9f5625bb79989780a268938227635caedcce2230843e2fc98fee5ffff8498R1-R5): Added `azureServiceConnectionName` and `azureSubscriptionID` variables.