### PR TITLE
Update adf_deploy_env_job.yml

### DIFF
--- a/jobs/adf_deploy_env_job.yml
+++ b/jobs/adf_deploy_env_job.yml
@@ -66,7 +66,7 @@ jobs:
               parameters:
                 azureSubscriptionName: ${{ variables.azureServiceConnectionName }}
                 scriptPath: ${{ variables. powerShellScriptPath }}
-                ScriptArguments: '-armTemplate "${{ variables.ARMTemplatePath }}" -ResourceGroupName ${{ variables.resourceGroupName }} -DataFactoryName ${{ variables.dataFactoryName }} -predeployment $false -deleteDeployment $true'
+                ScriptArguments: '-armTemplate "${{ variables.ARMTemplatePath }}" -ResourceGroupName ${{ variables.resourceGroupName }} -DataFactoryName ${{ variables.dataFactoryName }} -predeployment $false -deleteDeployment $false'
                 displayName: 'Start ADF Triggers'
                 workingDirectory: ${{ parameters.workingDirectory }}
 


### PR DESCRIPTION
This pull request includes a change to the `jobs/adf_deploy_env_job.yml` file. The change modifies the `ScriptArguments` parameter to ensure that deployments are not deleted after execution.

* [`jobs/adf_deploy_env_job.yml`](diffhunk://#diff-829e39d083f648648a9dc0832512a8df36b5d38ee3f577b3bf3e33a8d0301f78L69-R69): Updated the `ScriptArguments` parameter to set `-deleteDeployment` to `false`, preventing the deletion of deployments after execution.