### PR TITLE
Create azure_prd_variables.yml

### DIFF
--- a/variables/azure_prd_variables.yml
+++ b/variables/azure_prd_variables.yml
@@ -1,0 +1,5 @@
+variables:
+  - name: azureServiceConnectionName
+    value: 'AzureTstServiceConnection'
+  - name: azureSubscriptionID
+    value: 'b7d58423-b5cf-4fc4-98bb-446c92dc6ec5'


### PR DESCRIPTION
This pull request includes a small change to the `variables/azure_prd_variables.yml` file. The change adds new variables for Azure service connection and subscription ID.

* [`variables/azure_prd_variables.yml`](diffhunk://#diff-25e6eea03bd1a038e7622f462bd20d8212ba0dcf0e3f02f605c77a6b1d32da46R1-R5): Added `azureServiceConnectionName` and `azureSubscriptionID` variables.