### PR TITLE
Update/dotnetsdk

### DIFF
--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -3,12 +3,9 @@ parameters:
   type: string
   default: '8'
 
-variables:
-- name: sdkVersionText
-  value: ${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK v${{ variables.sdkVersionText }}
+  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}'
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}'
+  displayName: Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -5,7 +5,7 @@ parameters:
   
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion), ''), 'latest', parameters.sdkVersion ) }}'
+  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}'
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -5,7 +5,7 @@ parameters:
 
 steps:
 - task: UseDotNet@2
-  displayName: Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}
+  displayName: Use .NET SDK version ${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -2,10 +2,13 @@ parameters:
 - name: sdkVersion
   type: string
   default: '8'
-  
+
+variables:
+- name: sdkVersionText
+  value: ${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion, ''), 'latest', parameters.sdkVersion ) }}'
+  displayName: 'Use .NET SDK v${{ variables.sdkVersionText }}
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -5,7 +5,7 @@ parameters:
   
 steps:
 - task: UseDotNet@2
-  displayName: 'Use .NET SDK v${{ parameters.sdkVersion }}'
+  displayName: 'Use .NET SDK v${{ iif(eq(parameters.sdkVersion), ''), 'latest', parameters.sdkVersion ) }}'
   inputs:
     packageType: 'sdk'
     version: ${{ parameters.sdkVersion }}

--- a/tasks/dotnet_sdk_task.yml
+++ b/tasks/dotnet_sdk_task.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: sdkVersion
   type: string
-  default: '3.1.x'
+  default: '8'
   
 steps:
 - task: UseDotNet@2


### PR DESCRIPTION
This pull request includes an update to the `tasks/dotnet_sdk_task.yml` file to enhance the flexibility of specifying the .NET SDK version. The most important change is the update of the default SDK version and the improvement in the display name logic.

* Updated the default `sdkVersion` parameter from '3.1.x' to '8' to use a more recent version of the .NET SDK.
* Modified the `displayName` parameter to dynamically show 'latest' if the `sdkVersion` parameter is empty, providing clearer feedback in the task display name.